### PR TITLE
fix: add missing todo test status handling

### DIFF
--- a/src/jest-ci-spec-reporter.ts
+++ b/src/jest-ci-spec-reporter.ts
@@ -59,6 +59,8 @@ export default class JestCiSpecReporter implements Reporter {
                 return '\x1b[1m\x1b[32m[PASS]\x1b[0m';
             case 'pending':
                 return '\x1b[1m\x1b[33m[SKIP]\x1b[0m';
+            case 'todo':
+                return '\x1b[1m\x1b[34m[TODO]\x1b[0m';
             case 'failed':
             default:
                 return '\x1b[1m\x1b[31m[FAIL]\x1b[0m';


### PR DESCRIPTION
Currently, todo tests are incorrectly showing as failed.

Example: tests defined like this: `it.todo('test name')`